### PR TITLE
Create VolaDex trading terminal showcase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to `.env` and fill in the API keys to enable live market data.
+VITE_BIRDEYE_API_KEY=
+VITE_HELIUS_API_KEY=
+VITE_PUMPFUN_API_KEY=

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+pnpm-lock.yaml
+*.local
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# VolaDex
+# VolaDex – Solana Trading Terminal (Showcase)
+
+VolaDex is a concept-level, premium Solana trading terminal and landing experience inspired by best-in-class execution platforms. The
+project focuses on cinematic UI, ultra-polished interactions and data visualisations that highlight what a next-generation Solana
+workstation could feel like. **Trading actions are intentionally disabled – the experience is read-only for demonstration purposes.**
+
+## ✨ Highlights
+
+- **Immersive landing page** with hero animations, feature storytelling and live-looking market intelligence.
+- **Trading terminal mock** featuring a responsive grid layout, candlestick analytics, order book depth, trade tape and automation cockpit.
+- **Data integration-ready** hooks for Birdeye (OHLCV), Helius and Pump.fun feeds with graceful fallbacks to rich simulated datasets.
+- **Tailored Solana market set** with category filters, execution confidence gauges and risk simulation controls.
+- **Dark, glassmorphic visual language** powered by Tailwind CSS, custom gradients and the Lightweight Charts library.
+
+## 🛠️ Tech stack
+
+- [Vite](https://vitejs.dev/) + React 18 + TypeScript
+- [Tailwind CSS](https://tailwindcss.com/) for design system and utility styling
+- [TanStack Query](https://tanstack.com/query/latest) for data fetching and caching
+- [Lightweight Charts](https://tradingview.github.io/lightweight-charts/) for institutional-grade candlesticks
+- [Framer Motion](https://www.framer.com/motion/) & [Lucide Icons](https://lucide.dev/) for motion and iconography
+
+## 🚀 Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment variables**
+
+   Duplicate `.env.example` → `.env` and fill any keys you want to use. All values are optional – without them the UI falls back to
+   simulated market data.
+
+   ```bash
+   cp .env.example .env
+   # edit .env and provide your API keys
+   ```
+
+   | Variable               | Description                                               |
+   | ---------------------- | --------------------------------------------------------- |
+   | `VITE_BIRDEYE_API_KEY` | Enables live OHLCV + price data from the Birdeye API.     |
+   | `VITE_HELIUS_API_KEY`  | Reserved for wallet / smart money overlays (future use).  |
+   | `VITE_PUMPFUN_API_KEY` | Enables memecoin radar integrations (future use).         |
+
+3. **Run the dev server**
+
+   ```bash
+   npm run dev
+   ```
+
+   The application starts on `http://localhost:5173`. The landing page links to the trading terminal at `/trade`.
+
+4. **Available scripts**
+
+   | Script        | Description                         |
+   | ------------- | ----------------------------------- |
+   | `npm run dev` | Start the Vite development server.  |
+   | `npm run build` | Type-check and produce a production build. |
+   | `npm run preview` | Preview the production build locally. |
+   | `npm run lint` | Run ESLint on the entire project.   |
+
+## 📡 Data model & fallbacks
+
+- `usePriceData` attempts to fetch OHLCV from Birdeye using the provided API key. If the request fails or no key is supplied, curated
+  simulated candles are served so charts remain populated.
+- Order book depth, trade tape, automation hints and risk simulator leverage handcrafted data designed to mimic institutional dashboards.
+- The trading experience is non-interactive by design: buttons, toggles and sliders illustrate UX flows without triggering on-chain
+  actions.
+
+## 🧭 Project structure
+
+```
+src/
+  components/
+    chart/            // Reusable chart primitives
+    layout/           // Navbar, footer, layout shell
+    trading/          // Terminal-specific panels (order book, metrics, etc.)
+    ui/               // Shared UI building blocks
+  data/               // Sample market, candle and orderbook data
+  hooks/              // Data fetching hooks with API integration points
+  pages/              // Landing and trading terminal screens
+  styles/             // Tailwind global styles
+  lib/                // Formatting helpers, env utilities
+```
+
+## ⚠️ Disclaimer
+
+This repository is a **visual and UX showcase**. It does not place, sign or simulate real Solana transactions. Any API integrations are
+read-only and optional. Use the codebase as inspiration for high-end trading surfaces or extend it with your own backend / execution
+layer.
+
+---
+
+Crafted with a relentless focus on detail – VolaDex imagines what the future Solana trading OS could look like.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VolaDex Terminal</title>
+    <meta name="description" content="VolaDex – The ultimate Solana trading experience with institutional-grade analytics and immersive UI." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  </head>
+  <body class="bg-background text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "voladex",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.56.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^11.2.10",
+    "lightweight-charts": "^4.2.1",
+    "lucide-react": "^0.379.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.2",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,42 @@
+import { Route, Routes, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+
+import { AppLayout } from './components/layout/AppLayout';
+import LandingPage from './pages/LandingPage';
+import TradingTerminal from './pages/TradingTerminal';
+
+function ScrollToTop() {
+  const location = useLocation();
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [location.pathname]);
+
+  return null;
+}
+
+function Background() {
+  return (
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute -left-1/3 top-0 h-[60vh] w-[60vw] rounded-full bg-primary-600/20 blur-[180px]" />
+      <div className="absolute right-[-20vw] top-10 h-[55vh] w-[55vw] rounded-full bg-accent-500/20 blur-[180px]" />
+      <div className="absolute inset-x-0 bottom-[-30vh] h-[60vh] bg-gradient-to-t from-primary-500/10 via-transparent to-transparent" />
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="relative min-h-screen bg-background text-white">
+      <Background />
+      <ScrollToTop />
+      <AppLayout>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/trade" element={<TradingTerminal />} />
+        </Routes>
+      </AppLayout>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/chart/CandlestickChart.tsx
+++ b/src/components/chart/CandlestickChart.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react';
+import {
+  type IChartApi,
+  type ISeriesApi,
+  AreaSeriesPartialOptions,
+  CandlestickSeriesPartialOptions,
+  ColorType,
+  CrosshairMode,
+  createChart,
+} from 'lightweight-charts';
+
+import type { CandleDatum } from '../../types/trading';
+
+interface CandlestickChartProps {
+  data: CandleDatum[];
+}
+
+export function CandlestickChart({ data }: CandlestickChartProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi>();
+  const candleSeriesRef = useRef<ISeriesApi<'Candlestick'>>();
+  const baselineSeriesRef = useRef<ISeriesApi<'Area'>>();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const chart = createChart(container, {
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: 'rgba(255,255,255,0.65)',
+        fontFamily: 'Plus Jakarta Sans',
+      },
+      grid: {
+        vertLines: { color: 'rgba(255, 255, 255, 0.04)' },
+        horzLines: { color: 'rgba(255, 255, 255, 0.04)' },
+      },
+      rightPriceScale: {
+        borderVisible: false,
+        scaleMargins: { top: 0.08, bottom: 0.2 },
+      },
+      timeScale: {
+        borderVisible: false,
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      crosshair: {
+        mode: CrosshairMode.Magnet,
+        vertLine: { color: 'rgba(80, 227, 194, 0.4)', width: 1, style: 3 },
+        horzLine: { color: 'rgba(80, 227, 194, 0.4)', width: 1, style: 3 },
+      },
+      width: container.clientWidth,
+      height: 420,
+    });
+
+    chartRef.current = chart;
+
+    const candleSeriesOptions: CandlestickSeriesPartialOptions = {
+      upColor: '#2dd4bf',
+      downColor: '#ff5470',
+      borderVisible: false,
+      wickUpColor: '#2dd4bf',
+      wickDownColor: '#ff5470',
+    };
+
+    const series = chart.addCandlestickSeries(candleSeriesOptions);
+    candleSeriesRef.current = series;
+
+    const baselineSeriesOptions: AreaSeriesPartialOptions = {
+      lineColor: 'rgba(56, 107, 255, 0.6)',
+      topColor: 'rgba(56, 107, 255, 0.25)',
+      bottomColor: 'rgba(56, 107, 255, 0.05)',
+      priceLineVisible: false,
+    };
+    const baseline = chart.addAreaSeries(baselineSeriesOptions);
+    baselineSeriesRef.current = baseline;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === container) {
+          chart.applyOptions({ width: entry.contentRect.width });
+        }
+      }
+    });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      chart.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!candleSeriesRef.current || !baselineSeriesRef.current) return;
+    const mapped = data.map((item) => ({
+      time: item.time as number,
+      open: item.open,
+      high: item.high,
+      low: item.low,
+      close: item.close,
+    }));
+
+    candleSeriesRef.current.setData(mapped);
+    baselineSeriesRef.current.setData(
+      data.map((item) => ({ time: item.time as number, value: item.close })),
+    );
+
+    chartRef.current?.timeScale().fitContent();
+  }, [data]);
+
+  return <div ref={containerRef} className="h-[420px] w-full" />;
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import type { PropsWithChildren } from 'react';
+import { Navbar } from './Navbar';
+import { Footer } from './Footer';
+
+export function AppLayout({ children }: PropsWithChildren) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,104 @@
+import { Link } from 'react-router-dom';
+import { Github, Mail, Twitter } from 'lucide-react';
+
+const footerLinks = [
+  {
+    title: 'Product',
+    items: [
+      { label: 'Terminal', href: '/trade' },
+      { label: 'Analytics', href: '/#analytics' },
+      { label: 'Roadmap', href: '/#roadmap' },
+    ],
+  },
+  {
+    title: 'Company',
+    items: [
+      { label: 'About', href: '/#about' },
+      { label: 'Security', href: '/#security' },
+      { label: 'Careers', href: '/#careers' },
+    ],
+  },
+  {
+    title: 'Resources',
+    items: [
+      { label: 'Documentation', href: '/#docs' },
+      { label: 'Status', href: '/#status' },
+      { label: 'API', href: '/#api' },
+    ],
+  },
+];
+
+const social = [
+  { icon: Twitter, label: 'Twitter', href: 'https://twitter.com' },
+  { icon: Github, label: 'GitHub', href: 'https://github.com' },
+  { icon: Mail, label: 'Support', href: 'mailto:hello@voladex.io' },
+];
+
+export function Footer() {
+  return (
+    <footer className="relative border-t border-white/5 bg-black/40">
+      <div className="absolute inset-x-0 top-0 mx-auto h-px w-4/5 bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+      <div className="mx-auto grid max-w-7xl gap-12 px-6 py-16 lg:grid-cols-4">
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500 via-primary-600 to-accent-500 shadow-glow">
+              <span className="text-lg font-black uppercase text-black">V</span>
+            </div>
+            <div>
+              <p className="text-base font-semibold uppercase tracking-[0.35em] text-white/70">VolaDex</p>
+              <p className="text-xs text-white/50">Institutional Solana Trading OS</p>
+            </div>
+          </div>
+          <p className="max-w-sm text-sm text-white/60">
+            Built for teams that demand instant execution, predictive analytics and a level of polish that feels like the future of
+            decentralized trading.
+          </p>
+          <div className="flex items-center gap-3">
+            {social.map(({ icon: Icon, href, label }) => (
+              <a
+                key={label}
+                href={href}
+                aria-label={label}
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-white/70 transition hover:border-white/30 hover:text-white"
+              >
+                <Icon className="h-4 w-4" />
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {footerLinks.map((column) => (
+          <div key={column.title} className="space-y-4">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">{column.title}</h4>
+            <ul className="space-y-3 text-sm text-white/60">
+              {column.items.map((item) => (
+                <li key={item.label}>
+                  <Link to={item.href} className="transition hover:text-white">
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div className="border-t border-white/5 bg-black/20">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-6 text-xs text-white/40 sm:flex-row">
+          <p>© {new Date().getFullYear()} VolaDex Labs. All rights reserved.</p>
+          <div className="flex items-center gap-4">
+            <Link to="/#privacy" className="transition hover:text-white/80">
+              Privacy
+            </Link>
+            <Link to="/#terms" className="transition hover:text-white/80">
+              Terms
+            </Link>
+            <Link to="/#status" className="transition hover:text-white/80">
+              System status
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Link, NavLink } from 'react-router-dom';
+import { Menu, X, Zap } from 'lucide-react';
+import clsx from 'clsx';
+
+const navItems = [
+  { label: 'Discover', to: '/' },
+  { label: 'Terminal', to: '/trade' },
+  { label: 'Insights', to: '/#insights' },
+  { label: 'Docs', to: '/#docs' },
+];
+
+const activeClasses = 'text-white';
+
+export function Navbar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-40 backdrop-blur-xl">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-6 px-6 py-6">
+        <Link to="/" className="flex items-center gap-3">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500 via-primary-600 to-accent-500 shadow-glow">
+            <Zap className="h-6 w-6" />
+          </span>
+          <div>
+            <p className="text-lg font-semibold tracking-wide">VolaDex</p>
+            <p className="text-xs font-semibold uppercase text-accent-400 tracking-[0.3em]">Solana Terminal</p>
+          </div>
+        </Link>
+
+        <nav className="hidden items-center gap-10 text-sm font-medium text-white/70 lg:flex">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                clsx('transition hover:text-white', isActive && activeClasses)
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="hidden items-center gap-3 lg:flex">
+          <button className="rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/20 hover:text-white">
+            Book demo
+          </button>
+          <Link
+            to="/trade"
+            className="rounded-full bg-gradient-to-r from-primary-500 via-primary-400 to-accent-500 px-4 py-2 text-sm font-semibold text-black shadow-glow transition hover:scale-[1.02]"
+          >
+            Launch terminal
+          </Link>
+        </div>
+
+        <button
+          className="flex items-center justify-center rounded-xl border border-white/10 p-2 text-white/80 lg:hidden"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-label="Toggle navigation"
+        >
+          {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+      </div>
+
+      <div
+        className={clsx(
+          'lg:hidden',
+          'border-t border-white/5 bg-black/70 backdrop-blur-xl transition-all duration-300',
+          open ? 'max-h-96 opacity-100' : 'max-h-0 overflow-hidden opacity-0',
+        )}
+      >
+        <nav className="flex flex-col gap-4 px-6 py-6 text-sm font-medium text-white/70">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              onClick={() => setOpen(false)}
+              className={({ isActive }) =>
+                clsx('rounded-xl px-4 py-3 transition hover:bg-white/5 hover:text-white', isActive && 'bg-white/10 text-white')
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+          <div className="mt-2 flex flex-col gap-3">
+            <button className="rounded-xl border border-white/10 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/20 hover:text-white">
+              Book demo
+            </button>
+            <Link
+              to="/trade"
+              onClick={() => setOpen(false)}
+              className="rounded-xl bg-gradient-to-r from-primary-500 via-primary-400 to-accent-500 px-4 py-3 text-center text-sm font-semibold text-black shadow-glow transition hover:scale-[1.02]"
+            >
+              Launch terminal
+            </Link>
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/trading/MarketList.tsx
+++ b/src/components/trading/MarketList.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+
+import type { TokenMarket } from '../../data/markets';
+import { formatCompact, formatPercent } from '../../lib/format';
+
+interface MarketListProps {
+  markets: TokenMarket[];
+  selected: string;
+  onSelect: (market: TokenMarket) => void;
+}
+
+const filters: { label: string; value: TokenMarket['tag'] | 'all' }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Blue chip', value: 'bluechip' },
+  { label: 'DeFi', value: 'defi' },
+  { label: 'Perps', value: 'perp' },
+  { label: 'Memes', value: 'meme' },
+];
+
+export function MarketList({ markets, selected, onSelect }: MarketListProps) {
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<(typeof filters)[number]['value']>('all');
+
+  const filtered = useMemo(() => {
+    const lower = search.trim().toLowerCase();
+    return markets.filter((market) => {
+      const matchesFilter = filter === 'all' || market.tag === filter;
+      const matchesSearch =
+        !lower ||
+        market.name.toLowerCase().includes(lower) ||
+        market.symbol.toLowerCase().includes(lower);
+      return matchesFilter && matchesSearch;
+    });
+  }, [filter, markets, search]);
+
+  return (
+    <div className="flex h-full flex-col gap-5">
+      <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+        <Search className="h-4 w-4 text-white/40" />
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search tokens"
+          className="w-full bg-transparent text-sm text-white/80 placeholder:text-white/30 focus:outline-none"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-[0.25em] text-white/40">
+        {filters.map((item) => (
+          <button
+            key={item.value}
+            onClick={() => setFilter(item.value)}
+            className={`rounded-full border px-4 py-2 transition ${
+              filter === item.value
+                ? 'border-white/30 bg-white/10 text-white'
+                : 'border-white/5 bg-white/0 hover:border-white/20 hover:text-white/80'
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto pr-2">
+        {filtered.map((market) => {
+          const isActive = market.symbol === selected;
+          const changeTone = market.change24h >= 0 ? 'text-accent-400' : 'text-rose-400';
+          return (
+            <button
+              key={market.symbol}
+              onClick={() => onSelect(market)}
+              className={`group flex w-full flex-col gap-2 rounded-3xl border px-5 py-4 text-left transition ${
+                isActive
+                  ? 'border-white/40 bg-white/10 shadow-[0_25px_60px_-20px_rgba(56,107,255,0.55)]'
+                  : 'border-white/5 bg-white/[0.02] hover:border-white/20 hover:bg-white/10'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-white">{market.name}</p>
+                  <p className="text-[11px] uppercase tracking-[0.35em] text-white/40">{market.symbol}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm font-semibold text-white">${market.price.toFixed(market.price < 2 ? 4 : 2)}</p>
+                  <p className={`text-xs font-semibold ${changeTone}`}>{formatPercent(market.change24h)}</p>
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-white/40">
+                <span>1H {formatPercent(market.change1h)}</span>
+                <span>Vol {formatCompact(market.volume24h)}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/OrderBook.tsx
+++ b/src/components/trading/OrderBook.tsx
@@ -1,0 +1,51 @@
+import type { OrderBookLevel } from '../../types/trading';
+import { formatCompact } from '../../lib/format';
+
+interface OrderBookProps {
+  bids: OrderBookLevel[];
+  asks: OrderBookLevel[];
+}
+
+export function OrderBook({ bids, asks }: OrderBookProps) {
+  const maxSize = Math.max(
+    ...bids.map((bid) => bid.size),
+    ...asks.map((ask) => ask.size),
+  );
+
+  const renderRow = (level: OrderBookLevel, side: 'bid' | 'ask') => {
+    const width = `${(level.size / maxSize) * 100}%`;
+    const gradientColor = side === 'bid' ? 'from-accent-500/30' : 'from-rose-500/25';
+    const gradientDirection = side === 'bid' ? 'bg-gradient-to-l' : 'bg-gradient-to-r';
+    const textTone = side === 'bid' ? 'text-accent-200' : 'text-rose-200';
+
+    return (
+      <div key={`${side}-${level.price}`} className="relative overflow-hidden rounded-2xl border border-white/5 bg-black/40">
+        <div className={`absolute inset-y-0 ${side === 'bid' ? 'right-0' : 'left-0'} w-full`}>
+          <div className={`${gradientDirection} ${gradientColor} via-transparent to-transparent h-full opacity-60`} style={{ width }} />
+        </div>
+        <div className="relative grid grid-cols-3 px-4 py-3 text-xs font-mono">
+          <span className={`text-left ${textTone}`}>{level.price.toFixed(2)}</span>
+          <span className="text-center text-white/70">{formatCompact(level.size)}</span>
+          <span className="text-right text-white/40">{formatCompact(level.total)}</span>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Order book depth</h3>
+        <span className="text-xs uppercase tracking-[0.3em] text-white/30">Size × Price</span>
+      </div>
+      <div className="mt-5 grid gap-3">
+        <p className="text-[11px] uppercase tracking-[0.3em] text-white/40">Asks</p>
+        {asks.map((ask) => renderRow(ask, 'ask'))}
+      </div>
+      <div className="mt-6 grid gap-3">
+        <p className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bids</p>
+        {bids.map((bid) => renderRow(bid, 'bid'))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/PerformanceMetrics.tsx
+++ b/src/components/trading/PerformanceMetrics.tsx
@@ -1,0 +1,37 @@
+interface MetricItem {
+  label: string;
+  value: string;
+  delta?: string;
+  tone?: 'positive' | 'negative' | 'neutral';
+  description?: string;
+}
+
+interface PerformanceMetricsProps {
+  items: MetricItem[];
+}
+
+export function PerformanceMetrics({ items }: PerformanceMetricsProps) {
+  const toneMap = {
+    positive: 'text-accent-300',
+    negative: 'text-rose-300',
+    neutral: 'text-white/60',
+  } as const;
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+      <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Market intelligence</h3>
+      <div className="mt-6 grid gap-5 md:grid-cols-2">
+        {items.map((item) => (
+          <div key={item.label} className="rounded-2xl border border-white/10 bg-black/40 p-4">
+            <p className="text-[11px] uppercase tracking-[0.3em] text-white/40">{item.label}</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{item.value}</p>
+            {item.delta && (
+              <p className={`text-xs font-semibold ${toneMap[item.tone ?? 'neutral']}`}>{item.delta}</p>
+            )}
+            {item.description && <p className="mt-3 text-xs text-white/50">{item.description}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/StrategyPanel.tsx
+++ b/src/components/trading/StrategyPanel.tsx
@@ -1,0 +1,59 @@
+import { Bolt, Cpu, Radar } from 'lucide-react';
+
+export function StrategyPanel() {
+  const items = [
+    {
+      icon: <Bolt className="h-4 w-4" />,
+      title: 'Adaptive TWAP',
+      description: 'Slices 120k SOL with venue-aware speed control and liquidity backtesting.',
+      status: 'Armed',
+    },
+    {
+      icon: <Cpu className="h-4 w-4" />,
+      title: 'AI risk copilot',
+      description: 'Predictive VaR monitors perp skew and flags when delta hedges drift 10bps.',
+      status: 'Monitoring',
+    },
+    {
+      icon: <Radar className="h-4 w-4" />,
+      title: 'Whale radar',
+      description: 'Pulls Helius wallet clusters to detect inflows to top 25 vaults in real time.',
+      status: 'Live',
+    },
+  ];
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-black/50 to-black/80 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Automation cockpit</h3>
+          <p className="mt-2 text-sm text-white/60">
+            Orchestrate strategies with drag-and-drop logic. No trades will be executed in this showcase – everything is simulated for
+            design clarity.
+          </p>
+        </div>
+        <span className="rounded-full bg-white/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-accent-300">
+          Simulated
+        </span>
+      </div>
+      <div className="mt-6 space-y-4">
+        {items.map((item) => (
+          <div key={item.title} className="rounded-2xl border border-white/10 bg-black/40 p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-accent-400">{item.icon}</div>
+                <div>
+                  <p className="text-sm font-semibold text-white">{item.title}</p>
+                  <p className="text-xs text-white/50">{item.description}</p>
+                </div>
+              </div>
+              <span className="rounded-full border border-white/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white/60">
+                {item.status}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/TimeframeSelector.tsx
+++ b/src/components/trading/TimeframeSelector.tsx
@@ -1,0 +1,33 @@
+const intervals: { label: string; value: '1m' | '5m' | '15m' | '1h' | '4h' | '1d' }[] = [
+  { label: '1M', value: '1m' },
+  { label: '5M', value: '5m' },
+  { label: '15M', value: '15m' },
+  { label: '1H', value: '1h' },
+  { label: '4H', value: '4h' },
+  { label: '1D', value: '1d' },
+];
+
+interface TimeframeSelectorProps {
+  value: (typeof intervals)[number]['value'];
+  onChange: (value: (typeof intervals)[number]['value']) => void;
+}
+
+export function TimeframeSelector({ value, onChange }: TimeframeSelectorProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {intervals.map((interval) => (
+        <button
+          key={interval.value}
+          onClick={() => onChange(interval.value)}
+          className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+            value === interval.value
+              ? 'bg-white text-black shadow-glow'
+              : 'border border-white/10 bg-white/0 text-white/60 hover:border-white/20 hover:text-white'
+          }`}
+        >
+          {interval.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/trading/TradeTape.tsx
+++ b/src/components/trading/TradeTape.tsx
@@ -1,0 +1,36 @@
+import type { TradeItem } from '../../types/trading';
+import { formatCompact } from '../../lib/format';
+
+interface TradeTapeProps {
+  trades: TradeItem[];
+}
+
+export function TradeTape({ trades }: TradeTapeProps) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Recent trades</h3>
+        <span className="text-xs text-white/30">Simulated stream</span>
+      </div>
+      <div className="mt-4 grid grid-cols-4 gap-2 text-[11px] uppercase tracking-[0.25em] text-white/40">
+        <span>Time</span>
+        <span>Side</span>
+        <span>Size</span>
+        <span className="text-right">Price</span>
+      </div>
+      <div className="mt-4 space-y-2">
+        {trades.map((trade) => (
+          <div
+            key={`${trade.time}-${trade.price}-${trade.size}`}
+            className="grid grid-cols-4 gap-2 rounded-2xl bg-black/40 px-4 py-3 text-xs font-mono text-white/70"
+          >
+            <span>{trade.time}</span>
+            <span className={trade.side === 'buy' ? 'text-accent-300' : 'text-rose-300'}>{trade.side.toUpperCase()}</span>
+            <span>{formatCompact(trade.size)}</span>
+            <span className="text-right">{trade.price.toFixed(3)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/TradingStatsBar.tsx
+++ b/src/components/trading/TradingStatsBar.tsx
@@ -1,0 +1,47 @@
+import { formatCompact, formatCurrency, formatPercent } from '../../lib/format';
+
+interface TradingStatsBarProps {
+  symbol: string;
+  name: string;
+  price: number;
+  change24h: number;
+  high24h: number;
+  low24h: number;
+  volume24h: number;
+  source: 'birdeye' | 'sample';
+}
+
+export function TradingStatsBar({ symbol, name, price, change24h, high24h, low24h, volume24h, source }: TradingStatsBarProps) {
+  const changeTone = change24h >= 0 ? 'text-accent-400' : 'text-rose-400';
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-6">
+      <div>
+        <p className="text-xs uppercase tracking-[0.35em] text-white/50">{symbol}</p>
+        <div className="mt-2 flex items-end gap-3">
+          <p className="text-4xl font-semibold text-white">{formatCurrency(price, { maximumFractionDigits: price < 2 ? 4 : 2 })}</p>
+          <span className={`text-sm font-semibold ${changeTone}`}>{formatPercent(change24h)}</span>
+        </div>
+        <p className="text-sm text-white/60">{name}</p>
+      </div>
+      <div className="flex flex-wrap gap-10 text-xs uppercase tracking-[0.3em] text-white/50">
+        <div>
+          <p>24H High</p>
+          <p className="mt-2 text-base font-semibold text-white">{formatCurrency(high24h, { maximumFractionDigits: high24h < 2 ? 4 : 2 })}</p>
+        </div>
+        <div>
+          <p>24H Low</p>
+          <p className="mt-2 text-base font-semibold text-white">{formatCurrency(low24h, { maximumFractionDigits: low24h < 2 ? 4 : 2 })}</p>
+        </div>
+        <div>
+          <p>24H Volume</p>
+          <p className="mt-2 text-base font-semibold text-white">{formatCompact(volume24h)}</p>
+        </div>
+        <div>
+          <p>Data source</p>
+          <p className="mt-2 text-xs font-semibold text-accent-400">{source === 'birdeye' ? 'Birdeye live feed' : 'Simulated data'}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/GlowCard.tsx
+++ b/src/components/ui/GlowCard.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import clsx from 'clsx';
+
+interface GlowCardProps extends PropsWithChildren {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export function GlowCard({ title, description, icon, children, className }: GlowCardProps) {
+  return (
+    <div
+      className={clsx(
+        'relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl transition duration-500 hover:border-white/20 hover:shadow-[0_30px_60px_-15px_rgba(56,107,255,0.55)]',
+        className,
+      )}
+    >
+      <div className="absolute inset-0 opacity-0 transition duration-500 hover:opacity-100">
+        <div className="absolute -top-16 right-0 h-48 w-48 rounded-full bg-primary-500/30 blur-[120px]" />
+        <div className="absolute -bottom-16 left-0 h-48 w-48 rounded-full bg-accent-500/30 blur-[120px]" />
+      </div>
+      <div className="relative flex flex-col gap-5">
+        {icon && (
+          <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-accent-400">
+            {icon}
+          </div>
+        )}
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold text-white">{title}</h3>
+          {description && <p className="text-sm text-white/60">{description}</p>}
+        </div>
+        {children && <div className="text-sm text-white/70">{children}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,18 @@
+interface SectionHeaderProps {
+  eyebrow: string;
+  title: string;
+  description?: string;
+  align?: 'left' | 'center';
+}
+
+export function SectionHeader({ eyebrow, title, description, align = 'left' }: SectionHeaderProps) {
+  return (
+    <div className={align === 'center' ? 'mx-auto max-w-2xl text-center' : 'max-w-2xl'}>
+      <p className="text-xs font-semibold uppercase tracking-[0.4em] text-accent-400">{eyebrow}</p>
+      <h2 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">
+        {title}
+      </h2>
+      {description && <p className="mt-4 text-base text-white/60">{description}</p>}
+    </div>
+  );
+}

--- a/src/components/ui/StatisticPill.tsx
+++ b/src/components/ui/StatisticPill.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+interface StatisticPillProps {
+  label: string;
+  value: string;
+  change?: string;
+  icon?: ReactNode;
+}
+
+export function StatisticPill({ label, value, change, icon }: StatisticPillProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.28em] text-white/60">
+      {icon && <span className="text-accent-400">{icon}</span>}
+      <span>{label}</span>
+      <span className="text-white/80">{value}</span>
+      {change && <span className="font-semibold text-accent-400">{change}</span>}
+    </div>
+  );
+}

--- a/src/data/markets.ts
+++ b/src/data/markets.ts
@@ -1,0 +1,93 @@
+export interface TokenMarket {
+  name: string;
+  symbol: string;
+  address: string;
+  tag: 'bluechip' | 'defi' | 'perp' | 'meme';
+  price: number;
+  change1h: number;
+  change24h: number;
+  volume24h: number;
+}
+
+export const tokenMarkets: TokenMarket[] = [
+  {
+    name: 'Solana',
+    symbol: 'SOL',
+    address: 'So11111111111111111111111111111111111111112',
+    tag: 'bluechip',
+    price: 162.35,
+    change1h: 1.23,
+    change24h: 5.42,
+    volume24h: 1_245_000_000,
+  },
+  {
+    name: 'Jupiter',
+    symbol: 'JUP',
+    address: 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB',
+    tag: 'defi',
+    price: 1.23,
+    change1h: -0.42,
+    change24h: -2.18,
+    volume24h: 432_500_000,
+  },
+  {
+    name: 'Pyth Network',
+    symbol: 'PYTH',
+    address: 'PYTHm14mYh5sEaMdWrmxpry3X7DytHQZt81uAhvCUiQ',
+    tag: 'defi',
+    price: 0.87,
+    change1h: 0.86,
+    change24h: 3.91,
+    volume24h: 215_400_000,
+  },
+  {
+    name: 'Tensor',
+    symbol: 'TNSR',
+    address: 'TNSR6P7CkGyUz7Dnk3a1JpNggCB2A2nYqSCDtnznuaA',
+    tag: 'defi',
+    price: 4.18,
+    change1h: 1.18,
+    change24h: 8.34,
+    volume24h: 110_500_000,
+  },
+  {
+    name: 'dogwifhat',
+    symbol: 'WIF',
+    address: '8k4u8uGQCJpWznuaCG2KC9VmWHAXoJ1Bs8LojRx7iW4u',
+    tag: 'meme',
+    price: 2.34,
+    change1h: 2.8,
+    change24h: 12.6,
+    volume24h: 324_200_000,
+  },
+  {
+    name: 'Bonk',
+    symbol: 'BONK',
+    address: 'DezXAzRQB8hY2V6hW5jLCTH9rAPR7Xo4jua9whV7A6f',
+    tag: 'meme',
+    price: 0.000032,
+    change1h: -1.2,
+    change24h: 7.45,
+    volume24h: 298_000_000,
+  },
+  {
+    name: 'Meteora',
+    symbol: 'MET',
+    address: 'METoRALqVqD6oZX6mE6xPD58x35H5T6aBrZEcD3gjKUp',
+    tag: 'defi',
+    price: 18.45,
+    change1h: 0.76,
+    change24h: 4.21,
+    volume24h: 88_200_000,
+  },
+  {
+    name: 'Phoenix',
+    symbol: 'PHNX',
+    address: 'PHNXdo7E5Wn66iRSuLhM1cBh73PvvrLpzjAU6YewsG3x',
+    tag: 'perp',
+    price: 0.82,
+    change1h: -0.8,
+    change24h: 1.34,
+    volume24h: 65_700_000,
+  },
+];

--- a/src/data/sampleCandles.ts
+++ b/src/data/sampleCandles.ts
@@ -1,0 +1,24 @@
+import type { CandleDatum } from '../types/trading';
+
+const startTimestamp = Math.floor(Date.now() / 1000) - 60 * 120;
+
+function generateCandle(index: number): CandleDatum {
+  const basePrice = 150 + Math.sin(index / 6) * 5 + Math.cos(index / 14) * 3;
+  const drift = index * 0.05;
+  const open = basePrice + drift;
+  const close = open + (Math.sin(index / 3) * 2 + Math.random() * 1.5 - 0.75);
+  const high = Math.max(open, close) + Math.random() * 1.4;
+  const low = Math.min(open, close) - Math.random() * 1.4;
+  const volume = 1200 + Math.sin(index / 5) * 400 + Math.random() * 150;
+
+  return {
+    time: startTimestamp + index * 60,
+    open: Number(open.toFixed(2)),
+    high: Number(high.toFixed(2)),
+    low: Number(low.toFixed(2)),
+    close: Number(close.toFixed(2)),
+    volume: Number(volume.toFixed(2)),
+  };
+}
+
+export const sampleCandles: CandleDatum[] = Array.from({ length: 120 }, (_, index) => generateCandle(index));

--- a/src/data/sampleMarkets.ts
+++ b/src/data/sampleMarkets.ts
@@ -1,0 +1,48 @@
+export interface MarketSummary {
+  name: string;
+  symbol: string;
+  address: string;
+  price: number;
+  change24h: number;
+  liquidity: number;
+  volume24h: number;
+}
+
+export const marketSummaries: MarketSummary[] = [
+  {
+    name: 'Solana',
+    symbol: 'SOL',
+    address: 'So11111111111111111111111111111111111111112',
+    price: 162.35,
+    change24h: 5.42,
+    liquidity: 823_400_000,
+    volume24h: 1_245_000_000,
+  },
+  {
+    name: 'Jupiter',
+    symbol: 'JUP',
+    address: 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB',
+    price: 1.23,
+    change24h: -2.18,
+    liquidity: 164_000_000,
+    volume24h: 432_500_000,
+  },
+  {
+    name: 'Pyth Network',
+    symbol: 'PYTH',
+    address: 'PYTHm14mYh5sEaMdWrmxpry3X7DytHQZt81uAhvCUiQ',
+    price: 0.87,
+    change24h: 3.91,
+    liquidity: 96_200_000,
+    volume24h: 215_400_000,
+  },
+  {
+    name: 'Tensor',
+    symbol: 'TNSR',
+    address: 'TNSR6P7CkGyUz7Dnk3a1JpNggCB2A2nYqSCDtnznuaA',
+    price: 4.18,
+    change24h: 8.34,
+    liquidity: 42_800_000,
+    volume24h: 110_500_000,
+  },
+];

--- a/src/data/sampleOrderBook.ts
+++ b/src/data/sampleOrderBook.ts
@@ -1,0 +1,40 @@
+import type { OrderBookLevel, TradeItem } from '../types/trading';
+
+const basePrice = 162.35;
+
+export const bids: OrderBookLevel[] = Array.from({ length: 12 }, (_, i) => {
+  const price = basePrice - i * 0.08;
+  const size = 950 + Math.pow(1.4, i) * 12;
+  return {
+    price: Number(price.toFixed(2)),
+    size: Number(size.toFixed(2)),
+    total: Number((size * price).toFixed(2)),
+  };
+});
+
+export const asks: OrderBookLevel[] = Array.from({ length: 12 }, (_, i) => {
+  const price = basePrice + i * 0.08;
+  const size = 900 + Math.pow(1.35, i) * 11;
+  return {
+    price: Number(price.toFixed(2)),
+    size: Number(size.toFixed(2)),
+    total: Number((size * price).toFixed(2)),
+  };
+});
+
+const now = new Date();
+
+export const recentTrades: TradeItem[] = Array.from({ length: 18 }, (_, i) => {
+  const side: TradeItem['side'] = i % 2 === 0 ? 'buy' : 'sell';
+  const priceOffset = (Math.random() - 0.5) * 0.5;
+  const price = basePrice + priceOffset;
+  const size = 150 + Math.random() * 240;
+  const timestamp = new Date(now.getTime() - i * 45_000);
+
+  return {
+    side,
+    price: Number(price.toFixed(3)),
+    size: Number(size.toFixed(2)),
+    time: timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+  };
+});

--- a/src/hooks/usePriceData.ts
+++ b/src/hooks/usePriceData.ts
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { sampleCandles } from '../data/sampleCandles';
+import type { CandleDatum } from '../types/trading';
+import { env } from '../lib/env';
+
+interface UsePriceDataOptions {
+  address: string;
+  interval?: '1m' | '5m' | '15m' | '1h' | '4h' | '1d';
+}
+
+interface PriceDataResult {
+  source: 'birdeye' | 'sample';
+  candles: CandleDatum[];
+}
+
+async function fetchBirdeyeCandles(address: string, interval: string): Promise<CandleDatum[]> {
+  if (!env.birdeyeApiKey) {
+    throw new Error('Missing Birdeye API key');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const timeFrom = now - 60 * 60 * 24; // 24h
+  const url = new URL('https://public-api.birdeye.so/public/price_history');
+  url.searchParams.set('address', address);
+  url.searchParams.set('interval', interval);
+  url.searchParams.set('time_from', String(timeFrom));
+  url.searchParams.set('time_to', String(now));
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      accept: 'application/json',
+      'X-API-KEY': env.birdeyeApiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Birdeye request failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  const rawItems =
+    json?.data?.items ??
+    json?.data?.priceHistory ??
+    json?.data ??
+    json?.items ??
+    [];
+
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    throw new Error('Empty Birdeye payload');
+  }
+
+  const mapped: CandleDatum[] = rawItems
+    .map((item: any) => {
+      const time = Number(item?.unixTime ?? item?.time ?? item?.timestamp ?? 0);
+      const open = Number(item?.open ?? item?.o ?? item?.priceOpen ?? item?.startPrice ?? item?.value ?? 0);
+      const high = Number(item?.high ?? item?.h ?? item?.priceHigh ?? item?.max ?? open);
+      const low = Number(item?.low ?? item?.l ?? item?.priceLow ?? item?.min ?? open);
+      const close = Number(item?.close ?? item?.c ?? item?.priceClose ?? item?.endPrice ?? item?.value ?? open);
+      const volume = Number(item?.volume ?? item?.v ?? item?.baseVolume ?? item?.quoteVolume ?? 0);
+
+      if (!time) return null;
+      return {
+        time,
+        open,
+        high,
+        low,
+        close,
+        volume,
+      } satisfies CandleDatum;
+    })
+    .filter(Boolean);
+
+  if (!mapped.length) {
+    throw new Error('Unable to map Birdeye candles');
+  }
+
+  return mapped;
+}
+
+export function usePriceData({ address, interval = '5m' }: UsePriceDataOptions): PriceDataResult {
+  const query = useQuery({
+    queryKey: ['price', address, interval],
+    queryFn: () => fetchBirdeyeCandles(address, interval),
+    enabled: Boolean(address && env.birdeyeApiKey),
+  });
+
+  return useMemo(() => {
+    if (query.isSuccess && query.data.length > 0) {
+      return {
+        source: 'birdeye' as const,
+        candles: query.data,
+      };
+    }
+
+    return {
+      source: 'sample' as const,
+      candles: sampleCandles,
+    };
+  }, [query.data, query.isSuccess]);
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,5 @@
+export const env = {
+  birdeyeApiKey: import.meta.env.VITE_BIRDEYE_API_KEY ?? '',
+  heliusApiKey: import.meta.env.VITE_HELIUS_API_KEY ?? '',
+  pumpfunApiKey: import.meta.env.VITE_PUMPFUN_API_KEY ?? '',
+};

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,20 @@
+export function formatCurrency(value: number, options: Intl.NumberFormatOptions = {}) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    ...options,
+  }).format(value);
+}
+
+export function formatCompact(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatPercent(value: number, sign = true) {
+  const formatted = `${value > 0 && sign ? '+' : ''}${value.toFixed(2)}%`;
+  return formatted;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import App from './App';
+import './styles/global.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 1000 * 60,
+    },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,306 @@
+import { motion } from 'framer-motion';
+import { ArrowRight, BarChart2, Brain, Radar, ShieldCheck, Sparkles, TimerReset } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { GlowCard } from '../components/ui/GlowCard';
+import { SectionHeader } from '../components/ui/SectionHeader';
+import { StatisticPill } from '../components/ui/StatisticPill';
+import { marketSummaries } from '../data/sampleMarkets';
+import { formatCompact, formatCurrency, formatPercent } from '../lib/format';
+
+const heroStats = [
+  { label: 'Execution', value: '<12ms', change: 'Latency' },
+  { label: 'Coverage', value: '420+', change: 'Markets' },
+  { label: 'Integrations', value: '35', change: 'Protocols' },
+];
+
+const features = [
+  {
+    title: 'Institutional-grade toolkit',
+    description: 'Cross-margined portfolio view, latency-aware routing and custom Smart Order logic shaped for serious Solana teams.',
+    icon: <ShieldCheck className="h-6 w-6" />,
+  },
+  {
+    title: 'AI-guided execution',
+    description: 'Proactive flow alerts, predictive liquidity modelling and AI generated strategy blocks to supercharge your desk.',
+    icon: <Brain className="h-6 w-6" />,
+  },
+  {
+    title: 'Global risk visibility',
+    description: 'Unified perps + spot risk across venues with scenario stress-tests streamed in real time to every stakeholder.',
+    icon: <Radar className="h-6 w-6" />,
+  },
+  {
+    title: 'Pro-grade analytics',
+    description: 'Volatility surfaces, liquidity maps and cross-chain capital flows natively embedded into the trading terminal.',
+    icon: <BarChart2 className="h-6 w-6" />,
+  },
+];
+
+function TerminalPreview() {
+  return (
+    <div className="relative mx-auto max-w-3xl rounded-[36px] border border-white/10 bg-white/5 p-10 shadow-panel backdrop-blur-2xl">
+      <div className="absolute inset-x-10 top-10 h-[1px] bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+      <div className="flex flex-col gap-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.4em] text-white/60">SOL / USDC</p>
+            <p className="mt-2 text-3xl font-semibold text-white">$162.35</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/60 px-4 py-3 text-xs text-white/60">
+            <p className="font-mono text-accent-400">Latency 11.2ms</p>
+            <p className="font-mono text-white/40">Route: Meteora · Phoenix</p>
+          </div>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="overflow-hidden rounded-3xl border border-white/10 bg-black/50 p-6">
+            <div className="flex items-center justify-between text-xs text-white/50">
+              <span className="uppercase tracking-[0.3em]">Price action</span>
+              <span className="font-mono text-accent-400">1H +5.4%</span>
+            </div>
+            <div className="mt-6 h-48 rounded-2xl bg-gradient-to-br from-primary-500/20 via-transparent to-accent-500/20">
+              <div className="relative h-full w-full">
+                <div className="absolute inset-10 rounded-2xl bg-grid-pattern bg-[length:20px_20px] opacity-40" />
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <svg viewBox="0 0 320 160" className="h-40 w-full text-primary-400">
+                    <path
+                      d="M0 120 C40 100 70 110 110 80 C140 60 170 30 210 40 C240 48 260 90 320 70"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d="M0 140 C35 130 70 136 110 110 C150 86 180 50 220 60 C260 68 280 110 320 96"
+                      fill="none"
+                      stroke="rgba(80,227,194,0.55)"
+                      strokeWidth="1.5"
+                      strokeDasharray="6 6"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="rounded-3xl border border-white/10 bg-black/50 p-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Flow radar</p>
+              <div className="mt-3 space-y-3 text-sm">
+                <div className="flex items-center justify-between text-white/70">
+                  <span>Perp OI</span>
+                  <span className="font-mono text-white">$1.62B</span>
+                </div>
+                <div className="flex items-center justify-between text-white/70">
+                  <span>Spot Depth</span>
+                  <span className="font-mono text-white">$324M</span>
+                </div>
+                <div className="flex items-center justify-between text-white/70">
+                  <span>Funding Bias</span>
+                  <span className="font-mono text-accent-400">+12.4%</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-white/10 bg-black/50 p-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Automation</p>
+              <div className="mt-3 space-y-2 text-xs text-white/60">
+                <p>• Iceberg order triggered at $161.90</p>
+                <p>• Smart TWAP streaming via Phoenix</p>
+                <p>• Delta hedge rebalanced +8bps</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MarketPulse() {
+  return (
+    <div className="glass-panel rounded-[32px] border border-white/10 p-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-accent-400">Market pulse</p>
+          <p className="mt-2 text-lg font-semibold text-white">Live liquidity overview</p>
+        </div>
+        <Link to="/trade" className="text-sm font-medium text-accent-400 transition hover:text-accent-500">
+          Launch terminal →
+        </Link>
+      </div>
+      <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        {marketSummaries.map((market) => (
+          <div key={market.symbol} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold text-white">{market.name}</p>
+                <p className="text-xs uppercase tracking-[0.3em] text-white/50">{market.symbol}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-lg font-semibold text-white">{formatCurrency(market.price, { maximumFractionDigits: 3 })}</p>
+                <p className={market.change24h >= 0 ? 'text-xs font-semibold text-accent-400' : 'text-xs font-semibold text-rose-400'}>
+                  {formatPercent(market.change24h)}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-4 text-xs text-white/60">
+              <div>
+                <p className="uppercase tracking-[0.2em]">Liquidity</p>
+                <p className="mt-1 font-mono text-sm text-white">{formatCompact(market.liquidity)}</p>
+              </div>
+              <div>
+                <p className="uppercase tracking-[0.2em]">24h Volume</p>
+                <p className="mt-1 font-mono text-sm text-white">{formatCompact(market.volume24h)}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LandingPage() {
+  return (
+    <div className="relative">
+      <section className="relative overflow-hidden pb-24 pt-12">
+        <div className="absolute inset-0">
+          <div className="absolute inset-x-0 top-20 mx-auto h-[400px] w-[90%] rounded-[40px] bg-gradient-to-br from-white/10 via-primary-500/10 to-transparent blur-3xl" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,107,255,0.18),_transparent_55%)]" />
+        </div>
+        <div className="relative mx-auto flex max-w-7xl flex-col items-center gap-16 px-6 lg:flex-row lg:items-start">
+          <motion.div
+            className="max-w-2xl space-y-8"
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: 'easeOut' }}
+          >
+            <StatisticPill label="NEXT-GEN SOLANA" value="INSTITUTIONAL TERMINAL" icon={<Sparkles className="h-4 w-4" />} />
+            <h1 className="text-5xl font-semibold leading-tight sm:text-6xl">
+              The Solana trading operating system built for desks that need to move <span className="text-accent-400">faster</span> than
+              the market.
+            </h1>
+            <p className="text-lg text-white/70">
+              Route liquidity across every major venue, visualize risk in real time and orchestrate automated strategies with an
+              experience that outclasses every CeFi terminal you have ever used.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <Link
+                to="/trade"
+                className="group inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-primary-500 via-primary-400 to-accent-500 px-6 py-3 text-sm font-semibold text-black shadow-glow transition hover:scale-[1.02]"
+              >
+                Launch trading terminal
+                <span className="rounded-full bg-black/10 p-1 transition group-hover:translate-x-1">
+                  <ArrowRight className="h-4 w-4" />
+                </span>
+              </Link>
+              <button className="inline-flex items-center gap-3 rounded-full border border-white/10 px-6 py-3 text-sm font-semibold text-white/70 transition hover:border-white/20 hover:text-white">
+                Explore research deck
+                <TimerReset className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-8 flex flex-wrap gap-4 text-sm text-white/60">
+              {heroStats.map((stat) => (
+                <div key={stat.label} className="flex flex-col rounded-2xl border border-white/5 bg-white/5 px-5 py-4">
+                  <span className="text-xs uppercase tracking-[0.3em] text-white/50">{stat.label}</span>
+                  <span className="mt-2 text-2xl font-semibold text-white">{stat.value}</span>
+                  <span className="text-xs uppercase tracking-[0.2em] text-accent-400">{stat.change}</span>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+
+          <motion.div
+            className="w-full max-w-3xl"
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.9, delay: 0.2, ease: 'easeOut' }}
+          >
+            <TerminalPreview />
+          </motion.div>
+        </div>
+      </section>
+
+      <section id="analytics" className="section-gradient border-y border-white/5 py-24">
+        <div className="mx-auto flex max-w-7xl flex-col gap-12 px-6">
+          <SectionHeader
+            eyebrow="Signal engineered"
+            title="A complete execution & intelligence stack"
+            description="We rebuilt every primitive to feel cinematic. Rapid-scan liquidity heatmaps, AI risk copilots and modular automation blocks make
+              VolaDex the new benchmark for crypto-native teams."
+          />
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {features.map((feature) => (
+              <GlowCard key={feature.title} title={feature.title} description={feature.description} icon={feature.icon}>
+                <p className="mt-2 text-xs uppercase tracking-[0.25em] text-white/40">Realtime</p>
+                <p className="mt-1 text-sm text-white/70">
+                  Latency dashboards, split-second failover logic and continuous market replay ensure you never miss the move.
+                </p>
+              </GlowCard>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-24" id="insights">
+        <div className="mx-auto flex max-w-7xl flex-col gap-16 px-6 lg:flex-row lg:items-center">
+          <div className="lg:w-1/2">
+            <SectionHeader
+              eyebrow="Research intelligence"
+              title="Discover catalysts before they become consensus"
+              description="Monitor social velocity, pool depth, unlock schedules and whale movement in a single adaptive dashboard."
+            />
+            <div className="mt-10 space-y-4 text-sm text-white/70">
+              <p>
+                Our discovery engine syncs with Helius, Birdeye and Pump.fun to curate what matters. Every data point is contextualized
+                with AI summaries and risk scores so you can deploy capital with conviction.
+              </p>
+              <p>
+                Trigger alerts on memecoin launches, NFT floor dislocations or perp skew – then one-click route liquidity through your
+                preferred venues, all inside VolaDex.
+              </p>
+            </div>
+            <div className="mt-10 flex items-center gap-4 text-xs text-white/40">
+              <span className="rounded-full border border-white/10 px-4 py-2 uppercase tracking-[0.3em]">Helius Signals</span>
+              <span className="rounded-full border border-white/10 px-4 py-2 uppercase tracking-[0.3em]">Birdeye Depth</span>
+              <span className="rounded-full border border-white/10 px-4 py-2 uppercase tracking-[0.3em]">Pump.fun Radar</span>
+            </div>
+          </div>
+          <div className="lg:w-1/2">
+            <MarketPulse />
+          </div>
+        </div>
+      </section>
+
+      <section className="section-gradient border-y border-white/5 py-24" id="docs">
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-10 px-6 text-center">
+          <p className="text-xs uppercase tracking-[0.4em] text-accent-400">No more compromise</p>
+          <h3 className="text-4xl font-semibold">
+            Experience a trading environment where design meets execution. <span className="text-accent-400">Every pixel</span> has a job.
+          </h3>
+          <p className="max-w-3xl text-base text-white/70">
+            Deploy the VolaDex terminal within minutes. API-first architecture, granular permissioning, SOC2-ready audit trails and
+            enterprise support create a platform that scales with your ambitions.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-white/50">
+            <span className="rounded-full border border-white/10 px-5 py-2 uppercase tracking-[0.3em]">SAML / SSO</span>
+            <span className="rounded-full border border-white/10 px-5 py-2 uppercase tracking-[0.3em]">Granular Roles</span>
+            <span className="rounded-full border border-white/10 px-5 py-2 uppercase tracking-[0.3em]">99.99% SLA</span>
+            <span className="rounded-full border border-white/10 px-5 py-2 uppercase tracking-[0.3em]">24/7 Support</span>
+          </div>
+          <Link
+            to="/trade"
+            className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-primary-500 via-primary-400 to-accent-500 px-6 py-3 text-sm font-semibold text-black shadow-glow transition hover:scale-[1.02]"
+          >
+            Launch the experience
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default LandingPage;

--- a/src/pages/TradingTerminal.tsx
+++ b/src/pages/TradingTerminal.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from 'react';
+import { ArrowLeft, Rocket, Waves } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { CandlestickChart } from '../components/chart/CandlestickChart';
+import { MarketList } from '../components/trading/MarketList';
+import { OrderBook } from '../components/trading/OrderBook';
+import { PerformanceMetrics } from '../components/trading/PerformanceMetrics';
+import { StrategyPanel } from '../components/trading/StrategyPanel';
+import { TimeframeSelector } from '../components/trading/TimeframeSelector';
+import { TradeTape } from '../components/trading/TradeTape';
+import { TradingStatsBar } from '../components/trading/TradingStatsBar';
+import { tokenMarkets } from '../data/markets';
+import { asks, bids, recentTrades } from '../data/sampleOrderBook';
+import { usePriceData } from '../hooks/usePriceData';
+import { formatPercent } from '../lib/format';
+
+function createPerformanceMetrics(symbol: string) {
+  if (symbol === 'SOL') {
+    return [
+      {
+        label: 'Funding bias',
+        value: '+12.4bps',
+        delta: 'Stable last 4h',
+        tone: 'positive' as const,
+        description: 'Phoenix, Drift and Zeta perps converged. Bias remains long favouring makers.',
+      },
+      {
+        label: 'Cross-venue OI',
+        value: '$1.62B',
+        delta: '+4.2% 24h',
+        tone: 'positive' as const,
+        description: 'Open interest dominated by Drift (42%) with Jito vaults accumulating delta.',
+      },
+      {
+        label: 'Liquidity pockets',
+        value: '$324M',
+        delta: 'Stacked at $158.40',
+        tone: 'neutral' as const,
+        description: 'Meteora pools hold dense liquidity band between $158.4 – $160.2.',
+      },
+      {
+        label: 'Volatility surface',
+        value: '47% IV',
+        delta: '-3.1% daily',
+        tone: 'positive' as const,
+        description: '1W skew pricing risk premium lower as market anticipates compression.',
+      },
+    ];
+  }
+
+  return [
+    {
+      label: 'Funding bias',
+      value: '+4.3bps',
+      delta: 'Muted flow',
+      tone: 'neutral' as const,
+      description: 'Perp venues in balance. Expect chop with mean reversion bots dominating.',
+    },
+    {
+      label: 'Cross-venue OI',
+      value: '$324M',
+      delta: '+1.8% 24h',
+      tone: 'positive' as const,
+      description: 'Gradual inflows with no forced liquidations detected on-chain.',
+    },
+    {
+      label: 'Liquidity pockets',
+      value: '$68M',
+      delta: 'Stacked at range high',
+      tone: 'negative' as const,
+      description: 'Expect sell pressure near recent highs – run iceberg logic to slip less.',
+    },
+    {
+      label: 'Volatility surface',
+      value: '62% IV',
+      delta: '+6.2% daily',
+      tone: 'negative' as const,
+      description: 'Options desks repricing wings. Manage gamma if running neutral books.',
+    },
+  ];
+}
+
+const executionBlocks = [
+  { label: 'Smart routing', description: 'Auto routes across Phoenix, OpenBook, Meteora with failover in <30ms.' },
+  { label: 'Slippage guard', description: 'Dynamic slippage bands adjust with volatility & mempool density.' },
+  { label: 'Post-trade sync', description: 'Ledger, Fireblocks and Slack alerts triggered instantly after fills.' },
+];
+
+function TradingTerminal() {
+  const [selectedMarket, setSelectedMarket] = useState(tokenMarkets[0]);
+  const [interval, setInterval] = useState<'1m' | '5m' | '15m' | '1h' | '4h' | '1d'>('5m');
+  const { candles, source } = usePriceData({ address: selectedMarket.address, interval });
+
+  const analytics = useMemo(() => {
+    if (!candles.length) {
+      return {
+        price: selectedMarket.price,
+        change24h: selectedMarket.change24h,
+        high24h: selectedMarket.price,
+        low24h: selectedMarket.price,
+        volume24h: selectedMarket.volume24h,
+      };
+    }
+
+    const sorted = [...candles].sort((a, b) => a.time - b.time);
+    const first = sorted[0];
+    const last = sorted[sorted.length - 1];
+    const high = sorted.reduce((max, item) => Math.max(max, item.high), -Infinity);
+    const low = sorted.reduce((min, item) => Math.min(min, item.low), Infinity);
+    const volume = sorted.reduce((sum, item) => sum + item.volume, 0);
+    const change = ((last.close - first.open) / first.open) * 100;
+
+    return {
+      price: last.close,
+      change24h: change,
+      high24h: high,
+      low24h: low,
+      volume24h: volume,
+    };
+  }, [candles, selectedMarket]);
+
+  const performanceItems = useMemo(() => createPerformanceMetrics(selectedMarket.symbol), [selectedMarket.symbol]);
+
+  const executionStats = useMemo(() => {
+    const base = selectedMarket.symbol === 'SOL' ? 0.95 : 0.82;
+    return {
+      confidence: Math.round(base * 100),
+      latency: selectedMarket.symbol === 'SOL' ? '11.2ms' : '18.6ms',
+      venues: ['Phoenix', 'OpenBook', 'Meteora', 'Jupiter'],
+    };
+  }, [selectedMarket.symbol]);
+
+  return (
+    <div className="relative overflow-hidden py-16">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-1/3 top-0 h-[45vh] w-[55vw] rounded-full bg-primary-600/20 blur-3xl" />
+        <div className="absolute right-[-20vw] top-1/3 h-[50vh] w-[60vw] rounded-full bg-accent-500/20 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto max-w-7xl space-y-10 px-6">
+        <div className="flex flex-wrap items-center justify-between gap-6">
+          <div className="space-y-2">
+            <Link to="/" className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/40">
+              <ArrowLeft className="h-4 w-4" /> Back to discover
+            </Link>
+            <h1 className="text-4xl font-semibold text-white">VolaDex Terminal</h1>
+            <p className="max-w-xl text-sm text-white/60">
+              Precision-engineered Solana trading workstation. Charts, liquidity, automation – all elevated. Trading actions are
+              disabled in this showcase so you can explore design and analytics freely.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/5 px-5 py-4 text-xs uppercase tracking-[0.3em] text-white/50">
+            <p>Environment: <span className="font-semibold text-white">Simulation Mode</span></p>
+            <p>Data blend: Birdeye × Helius × Sample Streams</p>
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[280px_minmax(0,1fr)_340px]">
+          <div className="glass-panel h-full rounded-[32px] p-6">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Markets</h2>
+            <p className="mt-2 text-xs text-white/40">Tap any market to load analytics in the terminal canvas.</p>
+            <div className="mt-5 h-[720px] overflow-hidden">
+              <MarketList markets={tokenMarkets} selected={selectedMarket.symbol} onSelect={setSelectedMarket} />
+            </div>
+          </div>
+
+          <div className="glass-panel col-span-1 h-full rounded-[32px] p-6 lg:col-span-1">
+            <div className="space-y-6">
+              <TradingStatsBar
+                symbol={selectedMarket.symbol}
+                name={selectedMarket.name}
+                price={analytics.price}
+                change24h={analytics.change24h}
+                high24h={analytics.high24h}
+                low24h={analytics.low24h}
+                volume24h={analytics.volume24h}
+                source={source}
+              />
+
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <TimeframeSelector value={interval} onChange={setInterval} />
+                <span className="rounded-full border border-white/10 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/50">
+                  {source === 'birdeye' ? 'Live network' : 'Local demo'}
+                </span>
+              </div>
+
+              <div className="overflow-hidden rounded-[30px] border border-white/10 bg-black/40 p-4">
+                <CandlestickChart data={candles} />
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div className="rounded-3xl border border-white/10 bg-black/40 p-5">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/50">Execution confidence</p>
+                    <span className="text-xs text-white/40">{executionStats.latency}</span>
+                  </div>
+                  <div className="mt-4">
+                    <div className="relative h-3 rounded-full bg-white/10">
+                      <div
+                        className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-primary-500 via-primary-400 to-accent-500"
+                        style={{ width: `${executionStats.confidence}%` }}
+                      />
+                    </div>
+                    <p className="mt-3 text-2xl font-semibold text-white">{executionStats.confidence}%</p>
+                    <p className="text-xs text-white/50">Signal derived from venue depth, volatility and latency sensors.</p>
+                  </div>
+                  <div className="mt-5 flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.3em] text-white/40">
+                    {executionStats.venues.map((venue) => (
+                      <span key={venue} className="rounded-full border border-white/10 px-3 py-1">
+                        {venue}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-black/40 p-5">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/50">Playbook</p>
+                    <Rocket className="h-4 w-4 text-accent-400" />
+                  </div>
+                  <ul className="mt-4 space-y-3 text-sm text-white/70">
+                    {executionBlocks.map((item) => (
+                      <li key={item.label} className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                        <p className="font-semibold text-white">{item.label}</p>
+                        <p className="text-xs text-white/50">{item.description}</p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="glass-panel h-full rounded-[32px] p-6">
+            <div className="space-y-6">
+              <OrderBook bids={bids} asks={asks} />
+              <TradeTape trades={recentTrades} />
+              <StrategyPanel />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[280px_minmax(0,1fr)_340px]">
+          <div className="glass-panel rounded-[32px] p-6">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Flow annotations</h3>
+            <div className="mt-5 space-y-4 text-sm text-white/70">
+              <p>
+                • Helius smart money map flagged <span className="text-accent-300">12 wallet clusters</span> acquiring {selectedMarket.symbol} across 5 venues.
+              </p>
+              <p>
+                • Pump.fun radar detected <span className="text-accent-300">4 derivative launches</span> – track volatility bleed into spot markets.
+              </p>
+              <p>
+                • Birdeye liquidity sensors show <span className="text-accent-300">{formatPercent(selectedMarket.change24h)}</span> flow skew to aggressive buys.
+              </p>
+            </div>
+          </div>
+
+          <div className="glass-panel rounded-[32px] p-6 lg:col-span-1">
+            <PerformanceMetrics items={performanceItems} />
+          </div>
+
+          <div className="glass-panel rounded-[32px] p-6">
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+              <div className="flex items-center justify-between">
+                <p className="text-xs uppercase tracking-[0.3em] text-white/50">Risk simulator</p>
+                <Waves className="h-4 w-4 text-accent-400" />
+              </div>
+              <div className="mt-4 space-y-4 text-sm text-white/70">
+                <p>
+                  Adjust exposures and stress-test delta, gamma and liquidity shocks. Outputs update instantly without triggering on-chain
+                  actions.
+                </p>
+                <div className="grid gap-2 text-xs text-white/50">
+                  <label className="flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3">
+                    Position size
+                    <input type="range" min="0" max="100" defaultValue={60} className="ml-4 h-1 w-32 accent-accent-400" />
+                  </label>
+                  <label className="flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3">
+                    Hedge ratio
+                    <input type="range" min="0" max="100" defaultValue={40} className="ml-4 h-1 w-32 accent-primary-400" />
+                  </label>
+                  <label className="flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3">
+                    Drawdown limit
+                    <input type="range" min="0" max="100" defaultValue={25} className="ml-4 h-1 w-32 accent-rose-400" />
+                  </label>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-black/40 p-4 text-xs text-white/60">
+                  <p>Projected VaR (95%): <span className="font-semibold text-white">$2.4M</span></p>
+                  <p>Stress PnL @ -15% move: <span className="font-semibold text-rose-300">-$3.1M</span></p>
+                  <p>Hedge suggestion: tighten delta by <span className="text-accent-300">8.5%</span></p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TradingTerminal;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,49 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  --glass-bg: rgba(10, 12, 23, 0.8);
+  --glass-border: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  scrollbar-color: rgba(80, 227, 194, 0.4) rgba(80, 227, 194, 0.08);
+  scrollbar-width: thin;
+}
+
+body {
+  @apply bg-background text-white font-sans antialiased;
+  background-image: radial-gradient(circle at top left, rgba(80, 227, 194, 0.16), transparent 45%),
+    radial-gradient(circle at top right, rgba(56, 107, 255, 0.18), transparent 40%),
+    linear-gradient(180deg, rgba(8, 11, 21, 0.6), rgba(5, 6, 10, 0.98));
+}
+
+.glass-panel {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 24px 80px rgba(4, 8, 20, 0.55);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url('data:image/svg+xml,%3Csvg width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg"%3E%3Cdefs%3E%3ClinearGradient id="g" x1="1" y1="0" x2="0" y2="1"%3E%3Cstop stop-color="%2350e3c2" stop-opacity="0.06"/%3E%3Cstop stop-color="%23386bff" stop-opacity="0"/%3E%3C/linearGradient%3E%3CradialGradient id="r" cx="0.5" cy="0.5" r="0.5"%3E%3Cstop stop-color="%2350e3c2" stop-opacity="0.08"/%3E%3Cstop offset="1" stop-color="%23000000" stop-opacity="0"/%3E%3C/radialGradient%3E%3C/defs%3E%3Crect fill="url(%23g)" width="400" height="400"/%3E%3Cg fill="url(%23r)"%3E%3Ccircle cx="40" cy="120" r="2"/%3E%3Ccircle cx="140" cy="240" r="1"/%3E%3Ccircle cx="220" cy="60" r="1"/%3E%3Ccircle cx="340" cy="340" r="1"/%3E%3Ccircle cx="280" cy="180" r="1"/%3E%3C/g%3E%3C/svg%3E');
+  pointer-events: none;
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+
+.section-gradient {
+  background: radial-gradient(circle at top, rgba(56, 107, 255, 0.16), transparent 55%),
+    radial-gradient(circle at bottom, rgba(80, 227, 194, 0.12), transparent 60%);
+}
+
+::selection {
+  background: rgba(56, 107, 255, 0.6);
+  color: white;
+}

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -1,0 +1,21 @@
+export interface CandleDatum {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface OrderBookLevel {
+  price: number;
+  size: number;
+  total: number;
+}
+
+export interface TradeItem {
+  side: 'buy' | 'sell';
+  price: number;
+  size: number;
+  time: string;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,42 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui'],
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular'],
+      },
+      colors: {
+        primary: {
+          50: '#f1f7ff',
+          100: '#dbe7ff',
+          200: '#bfd4ff',
+          300: '#95b9ff',
+          400: '#6695ff',
+          500: '#386bff',
+          600: '#1f4df2',
+          700: '#163ed0',
+          800: '#1737a7',
+          900: '#172f86',
+        },
+        accent: {
+          400: '#50e3c2',
+          500: '#2dd4bf',
+          600: '#14b8a6',
+        },
+        background: '#05060a',
+        surface: 'rgba(15, 17, 26, 0.85)',
+      },
+      boxShadow: {
+        glow: '0 0 40px rgba(80, 227, 194, 0.45)',
+        panel: '0 20px 50px rgba(8, 12, 30, 0.45)',
+      },
+      backgroundImage: {
+        'grid-pattern': 'radial-gradient(circle at 1px 1px, rgba(80, 227, 194, 0.15) 1px, transparent 0)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind workspace with reusable layout, UI components, and theming for a premium Solana brand
- build an immersive landing page that highlights product capabilities and simulated market intelligence
- implement a non-trading terminal experience with lightweight charts, orderbook depth, automation cockpit, and Birdeye-ready data hooks

## Testing
- npm install *(fails: 403 Forbidden to npm registry in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d0f1120c832da79483cd6d717648